### PR TITLE
Add historical player selection for new games

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import { AuthProvider } from './contexts/AuthContext';
 import { GameSetup } from './components/GameSetup';
@@ -20,6 +20,18 @@ const Dashboard = () => {
   const { data, saveGame, deleteGame, importData, exportData, setActiveGame } = useDataStore();
   const { t } = useLanguage();
   const { requestLock, releaseLock } = useWakeLock();
+
+  const historicalPlayers = useMemo(() => {
+    const names = new Set<string>();
+    data.history.forEach(game => {
+      game.players.forEach(player => {
+        if (player.name.trim()) {
+          names.add(player.name.trim());
+        }
+      });
+    });
+    return Array.from(names).sort((a, b) => a.localeCompare(b));
+  }, [data.history]);
 
   const [view, setView] = useState<'landing' | 'home' | 'history' | 'stats' | 'about'>('landing');
   const [selectedGameType, setSelectedGameType] = useState<GameType>('rummy');
@@ -149,7 +161,13 @@ const Dashboard = () => {
     }
 
     if (!activeGame) {
-      return <GameSetup onStartGame={startGame} initialGameType={selectedGameType} />;
+      return (
+        <GameSetup
+          onStartGame={startGame}
+          initialGameType={selectedGameType}
+          historicalPlayers={historicalPlayers}
+        />
+      );
     }
 
     if (activeGame.status === 'completed') {

--- a/src/components/GameSetup.tsx
+++ b/src/components/GameSetup.tsx
@@ -7,9 +7,10 @@ interface GameSetupProps {
     onStartGame: (players: Player[], type: GameType) => void;
     initialPlayers?: Player[]; // For "Rematch" functionality
     initialGameType?: GameType;
+    historicalPlayers?: string[];
 }
 
-export const GameSetup: React.FC<GameSetupProps> = ({ onStartGame, initialPlayers, initialGameType }) => {
+export const GameSetup: React.FC<GameSetupProps> = ({ onStartGame, initialPlayers, initialGameType, historicalPlayers = [] }) => {
     const [gameType, setGameType] = useState<GameType>(initialGameType || 'rummy');
     const [players, setPlayers] = useState<Player[]>(
         initialPlayers || [
@@ -96,6 +97,7 @@ export const GameSetup: React.FC<GameSetupProps> = ({ onStartGame, initialPlayer
                         <div key={player.id} className="flex gap-2">
                             <input
                                 type="text"
+                                list="historical-players"
                                 placeholder={`Player ${index + 1}`}
                                 value={player.name}
                                 onChange={(e) => updateName(player.id, e.target.value)}
@@ -123,6 +125,12 @@ export const GameSetup: React.FC<GameSetupProps> = ({ onStartGame, initialPlayer
                     <Plus size={18} />
                     Add Player
                 </button>
+
+                <datalist id="historical-players">
+                    {historicalPlayers.map(name => (
+                        <option key={name} value={name} />
+                    ))}
+                </datalist>
 
                 <button
                     type="submit"


### PR DESCRIPTION
This change introduces a more convenient way to setup new games by suggesting player names from previous matches. 

Key changes:
- **App.tsx**: Added logic to aggregate all unique names from the game history, sorted alphabetically.
- **GameSetup.tsx**: Enhanced the player name input fields with a `<datalist>` element. This allows users to either type a new name or select from a dropdown of past players.

This implementation uses browser-native autocomplete features, ensuring it is lightweight and works well on both mobile and desktop.

---
*PR created automatically by Jules for task [18195947319806815697](https://jules.google.com/task/18195947319806815697) started by @augustose*